### PR TITLE
chore: standardize security workflow concurrency groups

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: secret-scan-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: semgrep-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Standardize concurrency group naming in security workflows to use GitHub's recommended pattern.

## Changes

✅ **secret-scan.yml**: Use `${{ github.workflow }}-${{ github.ref }}` pattern  
✅ **semgrep.yml**: Use `${{ github.workflow }}-${{ github.ref }}` pattern

## Benefits

- **Consistency**: Unified concurrency naming across all workflows
- **Maintainability**: Automatic workflow name detection reduces hardcoding
- **Performance**: Cancels stale security runs on busy PRs (keeps CI fast)
- **Best Practice**: Follows GitHub's recommended concurrency pattern

## Testing

- [x] Minimal YAML changes only
- [x] No app code changes
- [x] Preserves existing functionality
- [x] Required check name unchanged

## Documentation

GitHub Docs: [Using concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)

🤖 Generated with Claude Code