### PR TITLE
ci(docs): add optional docs link-check workflow with job-level gating

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,0 +1,47 @@
+name: docs-linkcheck
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # No workflow-level path filters. Gate at the job level to avoid Pending checks.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_changed: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'reports/**'
+              - '**/*.md'
+
+  linkcheck:
+    needs: detect
+    if: needs.detect.outputs.docs_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lychee on markdown
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: "--no-progress --require-https --accept 200,999 **/*.md"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  # Optional: explicit no-op job for observability on non-docs PRs
+  linkcheck-noop:
+    needs: detect
+    if: needs.detect.outputs.docs_changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No docs changes detected; skipping link check."


### PR DESCRIPTION
## Summary
- Add optional docs link-check workflow with job-level gating pattern
- Non-required check that won't block merges

## Details
- **Job-level gating**: Uses `dorny/paths-filter@v3` to avoid Pending status on non-docs PRs
- **Coverage**: `docs/`, `reports/`, and all `**/*.md` files
- **Tool**: `lycheeverse/lychee-action@v1` for comprehensive link validation
- **Observability**: Includes no-op job for transparency when skipped
- **Non-blocking**: This check is not required for branch protection

## Test Plan
- [ ] Verify workflow triggers on docs changes
- [ ] Verify workflow skips on non-docs changes with SKIPPED status
- [ ] Confirm link validation works on markdown files

🤖 Generated with [Claude Code](https://claude.ai/code)