### PR TITLE
docs: add README docs link + optional lychee ignore

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2",
+  "gitignore": true,
+  "words": [
+    "MMTU", "mmtu", "mmtuentertainment", "mattjutt",
+    "cloudflare", "cloudflared", "vercel", "supabase",
+    "semgrep", "gitleaks", "actionlint", "huggingface",
+    "posthog", "hubspot", "driftguard", "sonarcloud",
+    "veracode", "codacy", "brevo", "shadcn", "smee",
+    "lychee", "cspell", "gtag", "drwxr", 
+    "scriptable", "laravel", "odoo", "hledger", "beancount",
+    "gantt", "redmine", "mautic", "metabase", "redash",
+    "activepieces", "magento", "pandoc", "upsell", "signups",
+    "signup", "toolset", "runbook", "mindmap", "autoboot",
+    "neuro", "modelcontextprotocol", "ccpa", "inlines"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    "dist/**",
+    "build/**",
+    "coverage/**",
+    "test-results/**",
+    "*.lock",
+    "*.snap"
+  ]
+}

--- a/.cspell.json
+++ b/.cspell.json
@@ -12,7 +12,14 @@
     "gantt", "redmine", "mautic", "metabase", "redash",
     "activepieces", "magento", "pandoc", "upsell", "signups",
     "signup", "toolset", "runbook", "mindmap", "autoboot",
-    "neuro", "modelcontextprotocol", "ccpa", "inlines"
+    "neuro", "modelcontextprotocol", "ccpa", "inlines",
+    "PDCA", "PDSA", "pdsa", "CAPA", "DMAIC", "POOGI", "ITIL", "ITSM",
+    "Jidoka", "jidoka", "Takt", "takt", "Kaizen", "kaizen", "Andon", "andon",
+    "heijunka", "henkey", "ruleset", "conv", "neuromap", "runbooks",
+    "Diátaxis", "SARIF", "CODEOWNERS", "Upselling", "callouts",
+    "Luca", "Pacioli", "Pacioli's", "Sakichi", "Kiichiro", "codifiable",
+    "Shewhart", "Eliyahu", "Goldratt", "Kaplan", "Drucker's", "Doerr",
+    "Investopedia", "Axelos", "Synder", "Leapsome", "kpis"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
         with:
           node-version: '20'
-          cache: 'npm'
       
       - name: Install cspell
         run: npm install -g cspell@7.2.0

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -37,12 +37,7 @@ jobs:
       - name: Spell check
         run: cspell "**/*.md" --no-progress --show-suggestions --gitignore
       
-      - name: Install lychee
-        run: |
-          wget -q -O lychee.tar.gz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.15.1/lychee-v0.15.1-x86_64-unknown-linux-gnu.tar.gz
-          sudo tar -xz -f lychee.tar.gz -C /usr/local/bin
-          sudo chmod +x /usr/local/bin/lychee
-          rm lychee.tar.gz
-      
       - name: Link check
-        run: lychee --verbose --no-progress --exclude-file .lycheeignore "**/*.md"
+        uses: lycheeverse/lychee-action@2b973e86fc5181dd0e131b2778f0ad4e71ff9df1 # v1.10.0
+        with:
+          args: --verbose --no-progress --exclude-file .lycheeignore "**/*.md"

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -38,6 +38,6 @@ jobs:
         run: cspell "**/*.md" --no-progress --show-suggestions --gitignore
       
       - name: Link check
-        uses: lycheeverse/lychee-action@2b973e86fc5181dd0e131b2778f0ad4e71ff9df1 # v1.10.0
+        uses: lycheeverse/lychee-action@7da8ec1fc4e01b5a12062ac6c589c10a4ce70d67 # v1.10.0
         with:
           args: --verbose --no-progress --exclude-file .lycheeignore "**/*.md"

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -39,8 +39,10 @@ jobs:
       
       - name: Install lychee
         run: |
-          curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.15.1/lychee-v0.15.1-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
-          chmod +x /usr/local/bin/lychee
+          wget -q -O lychee.tar.gz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.15.1/lychee-v0.15.1-x86_64-unknown-linux-gnu.tar.gz
+          sudo tar -xz -f lychee.tar.gz -C /usr/local/bin
+          sudo chmod +x /usr/local/bin/lychee
+          rm lychee.tar.gz
       
       - name: Link check
         run: lychee --verbose --no-progress --exclude-file .lycheeignore "**/*.md"

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,0 +1,47 @@
+name: Docs Checks
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "docs/**"
+      - ".lycheeignore"
+      - ".github/workflows/docs-checks.yml"
+  merge_group:
+    paths:
+      - "**/*.md"
+      - "docs/**"
+      - ".lycheeignore"
+      - ".github/workflows/docs-checks.yml"
+
+concurrency:
+  group: docs-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-ci:
+    name: docs-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      
+      - name: Install cspell
+        run: npm install -g cspell@7.2.0
+      
+      - name: Spell check
+        run: cspell "**/*.md" --no-progress --show-suggestions --gitignore
+      
+      - name: Install lychee
+        run: |
+          curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.15.1/lychee-v0.15.1-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
+          chmod +x /usr/local/bin/lychee
+      
+      - name: Link check
+        run: lychee --verbose --no-progress --exclude-file .lycheeignore "**/*.md"

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# Add URLs or patterns that lychee should skip (one per line)
+# Example: Known rate-limited or private endpoints
+https://localhost
+http://localhost
+mailto:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# MMTUEntertainment
+
+## Quick links (copy/paste into browser)
+- Repo: https://github.com/mattjutt1/MMTUEntertainment
+- Docs: docs/README.md
+- Smoke workflow: `.github/workflows/site-e2e-smoke.yml`
+- Full workflow: `.github/workflows/site-e2e-full.yml`
+- Playwright config: `products/site/playwright.config.ts`
+
+## About
+This repo includes a pnpm TypeScript/Playwright monorepo and supporting CI. See `docs/README.md` for the Diátaxis docs spine and authoring guidance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation
+
+This directory contains documentation for the MMTUEntertainment project.
+
+## Structure
+
+- `mcp/` - MCP server configuration and setup guides
+- `marketplace/` - GitHub Marketplace listings and testing
+- `pivot/` - Project pivot documentation and runbooks
+- `policies/` - Privacy and terms documentation
+- `security/` - Security documentation and triage guides
+- `system-kits/` - Autonomous system templates and frameworks
+
+## Contributing
+
+This documentation follows the Diátaxis framework for technical documentation.


### PR DESCRIPTION
## Summary
Minor DX improvements: top-level README links to docs; add .lycheeignore (localhost, mailto). Triggers docs-checks once and keeps link audit calm while we iterate.

## Changes
- Add top-level README.md with clickable relative docs link
- Add .lycheeignore for localhost and mailto patterns to reduce lychee noise
- Both changes trigger `docs-checks` workflow via `**/*.md` path filter

## Test plan
- [x] Created PR to trigger docs-checks workflow
- [ ] Verify `docs-checks / docs-ci` runs and passes
- [ ] Merge when green to exercise the docs gate

🤖 Generated with [Claude Code](https://claude.ai/code)