### PR TITLE
docs(prompts): Claude Code orchestration (Opus plan → Sonnet exec) + MCP/IDE guardrails

### DIFF
--- a/.github/workflows/prompt-contract.yml
+++ b/.github/workflows/prompt-contract.yml
@@ -1,0 +1,11 @@
+name: Prompt Contract Lint
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate prompt contract
+        run: |
+          grep -q "Handoff Block" docs/prompts/claude-code-orchestration.md
+          echo "✅ Handoff markers present"

--- a/.github/workflows/site-e2e-smoke.yml
+++ b/.github/workflows/site-e2e-smoke.yml
@@ -62,18 +62,18 @@ jobs:
         run: cd products/site && node build.js
 
       - name: Run Site E2E Smoke Tests
-        run: pnpm test:e2e:site --project=chromium --reporter=line
+        run: pnpm test:e2e:site --project=chromium
         env:
           CI: true
 
       - name: Upload test results
-        if: failure()
+        if: failure() || success()
         uses: actions/upload-artifact@v4
         with:
           name: site-e2e-smoke-results-${{ github.run_id }}
           path: |
-            products/site/test-results/
-            products/site/playwright-report/
+            products/site/test-results/**
+            products/site/playwright-report/**
           retention-days: 7
 
       - name: Report test summary

--- a/docs/Branch-Protection.md
+++ b/docs/Branch-Protection.md
@@ -1,13 +1,24 @@
 # Branch Protection - MMTUEntertainment
 
-## Service Health Workflow Integration
+## Required CI Checks
 
-### Required Status Check
+### Service Health Workflow Integration
+
+**Status Check Name**: 
 ```
 Stack Health Check / Services Health Check (core)
 ```
 
 **Purpose**: Validates Business-Ops Stack health (Cal.com + Zammad) before merging infrastructure changes.
+
+### Site E2E Smoke Tests
+
+**Status Check Name**:
+```
+Site E2E Smoke Tests (≤3min)
+```
+
+**Purpose**: Validates critical revenue funnel paths and site functionality before merging. Runs Playwright tests with quarantine support for known brittle tests.
 
 **Evidence & Citations**: See `docs/best-practices/smoke-testing-references.md`
 
@@ -27,6 +38,7 @@ Navigate to: `Repository → Settings → Branches → Add rule`
   - ✅ **Require branches to be up to date before merging**
   - ✅ **Status checks that are required:**
     - `Stack Health Check / Services Health Check (core)`
+    - `Site E2E Smoke Tests (≤3min)`
 
 ### 3. Recommended Settings
 - ✅ **Require conversation resolution before merging**

--- a/docs/COMPREHENSIVE-TOOL-AUDIT.md
+++ b/docs/COMPREHENSIVE-TOOL-AUDIT.md
@@ -493,6 +493,13 @@ curl api.com | jq '.results' # Process API responses
 
 ---
 
+## 📝 Prompts
+
+- **Claude Code Orchestration:** `/docs/prompts/claude-code-orchestration.md`
+  - Opus=planner, Sonnet=executor, MCP/IDE integrated.
+
+---
+
 ## 📞 Support & Documentation
 
 - **Individual tool docs**: `/docs/mcp/[tool]-setup.md`

--- a/docs/prompts/claude-code-orchestration.md
+++ b/docs/prompts/claude-code-orchestration.md
@@ -1,0 +1,31 @@
+# Claude Code Orchestration Prompt (MMTU 2.0)
+## Role
+You are Claude Code operating in two modes:
+- **Opus (plan mode):** create a brief plan (≤10 steps) for the requested dev/ops task, citing tools from COMPREHENSIVE-TOOL-AUDIT.md.
+- **Sonnet (execute mode):** run one atomic step (≤10 minutes) via terminal; no multi-step chains.
+
+## Tooling (bind to MCP / IDE)
+- Use MCP servers declared in `/docs/COMPREHENSIVE-TOOL-AUDIT.md` (GitHub, CI, Drive/Sheets, Supabase, etc.).
+- In VS Code IDE mode, prefer workspace-aware paths and respect `.gitignore`.
+
+## Guardrails
+- Never touch prod data or durable storage without ops sign-off.
+- No secrets echoing; redact tokens.
+- Always propose PR-based changes; never push to `main`.
+
+## Required Output per Step
+- **Handoff Block**: Goal, Constraints, Files, Test/Run, Done criteria, Rollback.
+- **Commands**: exact shell commands; include dry-run if risky.
+- **Diff**: fenced `diff` blocks for file edits.
+- **ROI/Risk/Rollback**: one short line each.
+
+## Branch Discipline
+- `git checkout -b <area>/<desc>-YYYYMMDD`
+- `git push origin HEAD`
+
+## CI Etiquette
+- Conform to runtime budgets & concurrency gates.
+- If CI fails: name job, quote failing line, propose minimal diff, include local repro.
+
+## Done Criteria
+- Tests pass (smoke + affected suites), checks green, rollback documented.

--- a/products/site/e2e/revenue-path.spec.ts
+++ b/products/site/e2e/revenue-path.spec.ts
@@ -107,7 +107,7 @@ test.describe('Revenue Path E2E Tests @smoke @landing', () => {
 
   // Quarantined: content regression shows $999 product on Contact page.
   // TODO(#ISSUE_CONTACT_PAGE_CONTENT): Re-enable once Contact page no longer renders product pricing blocks.
-  test.fixme('Contact page has working email links @smoke @contact', async ({ page }) => {
+  test('Contact page has working email links @smoke @contact @quarantine', async ({ page }) => {
     await page.goto('/contact');
     
     // Check page loads
@@ -189,7 +189,7 @@ test.describe('Revenue Path E2E Tests @smoke @landing', () => {
 
   // Quarantined: expected CTA missing; likely content/aria-label drift.
   // TODO(#ISSUE_SEO_A11Y_CTA): Restore when 'Get security audit' link regains a stable selector or aria-label.
-  test.fixme('SEO and accessibility basics', async ({ page }) => {
+  test('SEO and accessibility basics @smoke @landing @quarantine', async ({ page }) => {
     await page.goto('/');
     
     // Check meta tags

--- a/products/site/playwright.config.ts
+++ b/products/site/playwright.config.ts
@@ -9,7 +9,11 @@ export default defineConfig({
 
   timeout: 30_000,
   fullyParallel: false,
-  reporter: [['github'], ['line']],
+  reporter: [
+    ['line'],
+    ['junit', { outputFile: 'products/site/test-results/junit.xml' }],
+    ['html', { outputFolder: 'products/site/playwright-report', open: 'never' }]
+  ],
 
   use: {
     baseURL: BASE,
@@ -28,10 +32,30 @@ export default defineConfig({
   },
 
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit',   use: { ...devices['Desktop Safari'] } },
-    { name: 'Mobile Chrome', use: { ...devices['Pixel 7'] } },
-    { name: 'Mobile Safari', use: { ...devices['iPhone 14'] } },
+    { 
+      name: 'chromium', 
+      use: { ...devices['Desktop Chrome'] },
+      grepInvert: process.env.CI ? /@quarantine/ : undefined,
+    },
+    { 
+      name: 'firefox',  
+      use: { ...devices['Desktop Firefox'] },
+      grepInvert: process.env.CI ? /@quarantine/ : undefined,
+    },
+    { 
+      name: 'webkit',   
+      use: { ...devices['Desktop Safari'] },
+      grepInvert: process.env.CI ? /@quarantine/ : undefined,
+    },
+    { 
+      name: 'Mobile Chrome', 
+      use: { ...devices['Pixel 7'] },
+      grepInvert: process.env.CI ? /@quarantine/ : undefined,
+    },
+    { 
+      name: 'Mobile Safari', 
+      use: { ...devices['iPhone 14'] },
+      grepInvert: process.env.CI ? /@quarantine/ : undefined,
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- Add Claude Code orchestration prompt with Opus planning → Sonnet execution workflow
- Wire to COMPREHENSIVE-TOOL-AUDIT.md for MCP/IDE integration
- Add CI lint to validate handoff contract markers
- **NEW:** Configure Playwright test reporters (JUnit + HTML) for better CI visibility
- **NEW:** Add artifact uploads for test results and reports
- **NEW:** Implement @quarantine tag support for brittle tests
- **NEW:** Update Branch Protection docs with exact CI job names

## Changes
- **New:** `/docs/prompts/claude-code-orchestration.md` - orchestration prompt
- **Updated:** `/docs/COMPREHENSIVE-TOOL-AUDIT.md` - added prompts section
- **New:** `.github/workflows/prompt-contract.yml` - CI validation
- **Updated:** `products/site/playwright.config.ts` - JUnit + HTML reporters + quarantine support
- **Updated:** `.github/workflows/site-e2e-smoke.yml` - artifact uploads
- **Updated:** `products/site/e2e/revenue-path.spec.ts` - quarantine 2 brittle tests
- **Updated:** `docs/Branch-Protection.md` - document required CI checks

## Test plan
- [x] Prompt file created with handoff blocks
- [x] Tool Audit references new prompt
- [x] CI lint workflow passes on PR
- [x] Site E2E Smoke Tests pass with quarantined tests
- [x] Branch protection docs updated with exact job names

## CI Status
- ✅ Site E2E Smoke Tests (≤3min) - **PASSING**
- ✅ Prompt Contract Lint - **PASSING**
- ⚠️ 2 scan jobs failing (pre-existing, unrelated to these changes)

## ROI/Risk/Rollback
- **ROI:** Faster PR cycles via consistent Opus→Sonnet loop; better test visibility with artifacts
- **Risk:** Over-automation if MCP servers mis-scoped; mitigated with guardrails
- **Rollback:** Single PR revert; no persistent infra changes

🤖 Generated with [Claude Code](https://claude.ai/code)