### PR TITLE
ci: fix docs-only filter exclusivity

### DIFF
--- a/.github/workflows/site-e2e-smoke.yml
+++ b/.github/workflows/site-e2e-smoke.yml
@@ -33,11 +33,16 @@ jobs:
               - '.cspell.json'
               - '.lycheeignore'
               - '.lychee.toml'
+      
+      - name: Debug filters
+        run: |
+          echo "site: ${{ steps.filter.outputs.site }}"
+          echo "docs_only: ${{ steps.filter.outputs.docs_only }}"
 
   smoke:
     name: 'Site E2E Smoke Tests (≤3min)'
     needs: detect
-    if: needs.detect.outputs.site_changed == 'true'
+    if: needs.detect.outputs.site_changed == 'true' && needs.detect.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 3
 


### PR DESCRIPTION
Ensure docs-only PRs run noop job instead of full Site E2E Smoke Tests. Adds explicit exclusivity logic and debug logging. 

## Problem Fixed
- PR #49 (docs-only) was triggering full E2E tests instead of smoke-docs-noop
- Caused 3m10s timeout and blocked docs-only PR merges

## Changes Made
✅ **Debug logging**: Added filter output visibility in detect job
✅ **Exclusivity logic**: Updated main smoke job condition to exclude docs_only PRs
✅ **Performance**: Prevents unnecessary E2E runs on documentation changes

## ROI
- **Saves CI time**: Docs-only PRs skip expensive 3min E2E tests
- **Avoids false gating**: Documentation changes won't be blocked by flaky E2E tests  
- **Maintains protection**: Branch protection requirements still satisfied via noop jobs

## Testing
This fix should allow PR #49 to merge cleanly using the smoke-docs-noop job.

🤖 Generated with [Claude Code](https://claude.ai/code)