### PR TITLE
verify: mixed-change workflow path (post-logic-fix)

### DIFF
--- a/docs/verification-mixed-postfix.md
+++ b/docs/verification-mixed-postfix.md
@@ -1,0 +1,17 @@
+# Mixed-Change Verification (Post-Fix)
+
+**Date**: Fri Aug 22 06:27:00 UTC 2025
+**Purpose**: Verify that mixed changes (site + docs) trigger full E2E tests post-logic-fix
+
+**Expected Behavior**: 
+- Filter outputs: `site: true`, `docs_only: true`
+- Workflow execution: Full E2E smoke tests (≤3min runtime)
+- Steps executed: Checkout, Setup PNPM, Install deps, Build site, Run tests, Upload artifacts
+- Result: SUCCESS with proper E2E execution (not noop)
+
+This verifies the fix for the critical logic bug where the condition:
+`site_changed == 'true' && docs_only != 'true'`
+
+Was incorrectly evaluating to false for mixed changes, causing E2E tests to be skipped.
+
+The corrected condition `site_changed == 'true'` should now properly trigger E2E tests.

--- a/products/site/playwright.config.ts
+++ b/products/site/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 // Mixed-change verification: 2025-08-22T05:51:00Z
+// Mixed-change RETEST post-fix: 2025-08-22T06:27:00Z
 const PORT = Number(process.env.PORT ?? 4173);
 const BASE = `http://localhost:${PORT}`;
 


### PR DESCRIPTION
**CRITICAL TEST**: Verifies mixed changes (site + docs) now trigger full E2E tests instead of noop after logic fix.

**Expected**: 
- Filter outputs: site=true, docs_only=true
- **Full E2E execution** (≤3min runtime) - NOT 3s noop
- All E2E steps executed: Checkout, Setup, Install, Build, Test, Upload
- Required check: SUCCESS

**This validates the fix for the boolean logic bug in PR #54**