### PR TITLE
fix(ci): replace wildcard *.md pattern with specific patterns

### DIFF
--- a/.github/workflows/site-e2e-smoke.yml
+++ b/.github/workflows/site-e2e-smoke.yml
@@ -29,7 +29,8 @@ jobs:
               - '!archive/**'
             docs_only:
               - 'docs/**'
-              - '*.md'
+              - 'README.md'
+              - 'CHANGELOG.md'
               - '.cspell.json'
               - '.lycheeignore'
               - '.lychee.toml'


### PR DESCRIPTION
**Root Cause**: The wildcard pattern `*.md` in the `docs_only` filter was causing files like `docs/verification-log.md` to match **both** `site` and `docs_only` filters.

**Problem**: This made `site_changed=true` for docs-only PRs, causing E2E tests to run instead of noop.

**Fix**: Replace `*.md` with specific patterns:
- `README.md`
- `CHANGELOG.md`

**Expected**: Files under `docs/` will now only match `docs_only` filter, enabling proper noop behavior.