### PR TITLE
fix(ci): add explicit exclusions to site path filter

### DIFF
--- a/.github/workflows/site-e2e-smoke.yml
+++ b/.github/workflows/site-e2e-smoke.yml
@@ -26,6 +26,9 @@ jobs:
             site:
               - 'products/site/**'
               - '.github/workflows/site-e2e-smoke.yml'
+              - '!docs/**'
+              - '!README.md'
+              - '!CHANGELOG.md'
               - '!archive/**'
             docs_only:
               - 'docs/**'


### PR DESCRIPTION
**Root Cause**: Site filter had no exclusions, causing it to match ANY changed file by default

**Problem**: `docs/verification-log.md` was matching both `site` and `docs_only` filters

**Fix**: Add explicit exclusions to site filter:
- `!docs/**`
- `!README.md`
- `!CHANGELOG.md`

**Expected**: Docs-only changes will now only match `docs_only` filter, enabling noop behavior