### PR TITLE
docs(front-desk): add webhooks placeholder

### DIFF
--- a/docs/front-desk/webhooks.md
+++ b/docs/front-desk/webhooks.md
@@ -1,0 +1,5 @@
+# Webhooks Setup Placeholder
+
+This file reserves the location for instructions and documentation on configuring intake webhooks (Zammad/FreeScout) to the Front Desk via n8n.
+
+Further details and screenshots will be added once the webhook has been configured in the admin UI.


### PR DESCRIPTION
Add placeholder documentation file for configuring intake webhooks (Zammad/FreeScout) to the Front Desk via n8n. This file will be updated with step-by-step instructions and screenshots once the webhook is configured in the admin UI.

This PR addresses M3 (Webhooks) by establishing the docs/front-desk/webhooks.md file. Subsequent steps will involve creating the actual webhook in the helpdesk admin UI and updating this documentation accordingly.

- [ ] Configuration complete in Zammad/FreeScout and n8n
- [ ] Documentation updated with details and screenshots

